### PR TITLE
Added the unique garbage characters to the array of special artifacts

### DIFF
--- a/src/AI-NLP/AIWordTokenizer.class.st
+++ b/src/AI-NLP/AIWordTokenizer.class.st
@@ -72,15 +72,24 @@ AIWordTokenizer >> nextIsInvalid: aStream [
 
 { #category : #defaults }
 AIWordTokenizer >> specialArtifacts [
+
 	" Answer a <Collection> of <String> representing artifacts commonly found in natural language written text. Generate them in reverse order so larger occurrences can be detected first. "
-	
-	^ #('<br />' ':-)' ':-(' ':)' ':(') asOrderedCollection 
-	addAll: (
-		(#($- $! $? $* $( $) $\ $/ $| $_ $# $> $< $% $" $$ $, $.) collect: [ : repChar |
-			(2 to: 10) reversed collect: [ : rep | String new: rep withAll: repChar ] ]) joinUsing: Array empty
-	);
-	yourself 
-	
+
+	| emojisAndHtmlCharacters garbageCharacters |
+	emojisAndHtmlCharacters := #( '<br />' ':-)' ':-(' ':)' ':(' )
+		                           asOrderedCollection.
+	garbageCharacters := ((#( $- $! $? $* $( $) $\ $/ $| $_ $# $> $< $%
+	                          $" $$ $, $. ) collect: [ :repChar | 
+		                       (1 to: 10) reversed collect: [ :rep | 
+			                       String new: rep withAll: repChar ] ]) 
+		                      joinUsing: Array empty) asOrderedCollection.
+	"We do not want to remove the dot . since is a grammar sign that indicates the end of a sentence. The same for the question mark ? the comma , and the exclamation mark !"
+	garbageCharacters
+		remove: '.';
+		remove: '?';
+		remove: ',';
+		remove: '!'.
+	^ emojisAndHtmlCharacters , garbageCharacters
 ]
 
 { #category : #tokenizing }


### PR DESCRIPTION
`AIWordTokenizer new specialArtifacts` method returns no individual characters, only combinations of two of more. This can cause some problems, like this:
![Screenshot 2021-07-19 at 10 52 35](https://user-images.githubusercontent.com/33934979/126140806-cf84f97e-e0e6-49b5-acf1-d352e34523b2.png)
As it can be seen, the two `> >` characters were not removed because the `specialArtifacts` collection does not contains individual characters.

This PR fixed that. Now the `specialArtifacts` collection does includes individual garbage characters, but does not includes the ones that are grammatically meaningful. Like: , . ? ! 
See the method comments